### PR TITLE
Added monkeyrunner script to get metafeatures for all datasets

### DIFF
--- a/metafeatures/get_metafeatures.py
+++ b/metafeatures/get_metafeatures.py
@@ -1,0 +1,40 @@
+"""
+Script to get metafeatures for all datasets stored in the ../data folder.
+Dumps all the results in a csv called data_metafeatures.csv
+"""
+
+from glob import glob
+import pandas as pd
+
+from dataset_describe import Dataset
+from collections import OrderedDict
+
+
+def get_metafeatures(df):
+    dataset = Dataset(df, dependent_col = 'class', prediction_type='classification')
+   
+    meta_features = OrderedDict()
+    for i in dir(dataset):
+        result = getattr(dataset, i)
+        # print i
+        if not i.startswith('__') and not i.startswith('_') and hasattr(result, '__call__'):
+            meta_features[i] = result()
+
+    return meta_features
+
+
+def main():
+    meta_features = []
+    for i,dataset in enumerate(glob('../data/*')):
+        # Read the data set into memory
+        print 'Processing {0}'.format(dataset)
+        input_data = pd.read_csv(dataset, compression='gzip', sep='\t')
+        meta_features.append(get_metafeatures(input_data))
+        
+        # For testing purposes.
+        # if i == 5:
+        #     pd.DataFrame(meta_features).to_csv('data_metafeatures.csv')
+        #     break
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Added the method to read ../data folder and get metafeatures for each dataset.

Few things to note.
 - Some metafeatures operate only upon categorical variables and hence the Dataset class needs to know which columns were categorical. The way I automated it was to look for non-numerical columns. In our datasets the categorical columns are already LabelEncoded and hence my non-numeric hack fails. Are you doing any pre-processing on your end?
Datasets usually don't come LabelEncoded right?

How do others handle it?
- OpenML and automl use [ARFF](Attribute-Relation File Format (ARFF)) datasets as input.

