### PR TITLE
Auto category discovery

### DIFF
--- a/metafeatures/dataset_describe.py
+++ b/metafeatures/dataset_describe.py
@@ -545,6 +545,119 @@ class Dataset:
 
         return skew(kurtosisses, bias = False)
 
+    #----------------------------------------------------------------------
+    # Skew related - For all non-categorical columns
+    skew_dict = None
+    def _get_skew_per_num_column(self):
+        """Sets an dictionary with skew measure per numerical column"""
+
+        if self.skew_dict == None:
+            self.skew_dict = {}
+            numerical_cols = list(set(self.independent_col) - set(self.categorical_cols)) 
+            for column in numerical_cols:
+                self.skew_dict[column] = skew(self.df[column].dropna(), bias = False)
+            return self.skew_dict
+        else:
+            return self.skew_dict
+
+    def skew_mean(self):
+        """ Mean skew in all numerical columns """
+
+        skew_dict = self._get_skew_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not skew_dict:
+            return np.nan
+        
+        skews = skew_dict.values()
+
+        return np.nanmean(skews)
+
+
+
+    def skew_median(self):
+        """ Median skew in all numerical columns """
+
+        skew_dict = self._get_skew_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not skew_dict:
+            return np.nan
+        
+        skews = skew_dict.values()
+
+        return np.nanmedian(skews)
+
+
+
+    def skew_min(self):
+        """ Min skew in all numerical columns """
+
+        skew_dict = self._get_skew_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not skew_dict:
+            return np.nan
+        
+        skews = skew_dict.values()
+
+        return np.min(skews)
+
+
+    def skew_max(self):
+        """ Min skew in all numerical columns """
+
+        skew_dict = self._get_skew_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not skew_dict:
+            return np.nan
+        
+        skews = skew_dict.values()
+
+        return np.max(skews)
+
+
+    def skew_std(self):
+        """ std skew in all numerical columns """
+
+        skew_dict = self._get_skew_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not skew_dict:
+            return np.nan
+        
+        skews = skew_dict.values()
+
+        return np.nanstd(skews)
+
+
+    def skew_kurtosis(self):
+        """ kurtosis of skew in all numerical columns """
+
+        skew_dict = self._get_skew_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not skew_dict:
+            return np.nan
+        
+        skews = skew_dict.values()
+
+        return kurtosis(skews, bias = False)
+
+    def skew_skew(self):
+        """ skew of skew in all numerical columns """
+
+        skew_dict = self._get_skew_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not skew_dict:
+            return np.nan
+        
+        skews = skew_dict.values()
+
+        return skew(skews, bias = False)
+
 
 
 

--- a/metafeatures/dataset_describe.py
+++ b/metafeatures/dataset_describe.py
@@ -13,7 +13,7 @@ Contact: Harsh Nisar GH: harshnisar
 import pandas as pd
 import numpy as np
 from sklearn.preprocessing import OneHotEncoder, LabelEncoder
-
+from scipy.stats import kurtosis, skew
 class Dataset:
     """
     Initialize the dataset and give user the option to set some
@@ -433,4 +433,120 @@ class Dataset:
 
 
     ##todo: Note we can evaluate symbol probabilities too.
+
+    #----------------------------------------------------------------------
+    # Kustosis related - For all non-categorical columns
+    kurtosis_dict = None
+    def _get_kurtosis_per_num_column(self):
+        """Sets an dictionary with kurtosis per numerical column"""
+
+        if self.kurtosis_dict == None:
+            self.kurtosis_dict = {}
+            numerical_cols = list(set(self.independent_col) - set(self.categorical_cols)) 
+            for column in numerical_cols:
+                self.kurtosis_dict[column] = kurtosis(self.df[column].dropna(), bias = False)
+            return self.kurtosis_dict
+        else:
+            return self.kurtosis_dict
+
+    def kurtosis_mean(self):
+        """ Mean kurtosis per columns """
+
+        kurtosis_dict = self._get_kurtosis_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not kurtosis_dict:
+            return np.nan
+        
+        kurtosisses = kurtosis_dict.values()
+
+        return np.nanmean(kurtosisses)
+
+    def kurtosis_median(self):
+        """ Median kurtosis per columns """
+
+        kurtosis_dict = self._get_kurtosis_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not kurtosis_dict:
+            return np.nan
+        
+        kurtosisses = kurtosis_dict.values()
+
+        return np.nanmedian(kurtosisses)
+
+
+    def kurtosis_min(self):
+        """ Min kurtosis per columns """
+
+        kurtosis_dict = self._get_kurtosis_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not kurtosis_dict:
+            return np.nan
+        
+        kurtosisses = kurtosis_dict.values()
+
+        return np.min(kurtosisses)
+
+
+    def kurtosis_max(self):
+        """ Max kurtosis per columns """
+
+        kurtosis_dict = self._get_kurtosis_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not kurtosis_dict:
+            return np.nan
+        
+        kurtosisses = kurtosis_dict.values()
+
+        return np.max(kurtosisses)
+
+
+    def kurtosis_std(self):
+        """ STD of kurtosis per columns """
+
+        kurtosis_dict = self._get_kurtosis_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not kurtosis_dict:
+            return np.nan
+        
+        kurtosisses = kurtosis_dict.values()
+
+        return np.nanstd(kurtosisses)
+
+
+    def kurtosis_kurtosis(self):
+        """ Kurtosis of kurtosis per columns """
+
+        kurtosis_dict = self._get_kurtosis_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not kurtosis_dict:
+            return np.nan
+        
+        kurtosisses = kurtosis_dict.values()
+
+        return kurtosis(kurtosisses, bias = False)
+
+    
+    def kurtosis_skew(self):
+        """ skew of kurtosis per columns """
+
+        kurtosis_dict = self._get_kurtosis_per_num_column()
+        ## None is for checking empty, no categorical columns
+        
+        if not kurtosis_dict:
+            return np.nan
+        
+        kurtosisses = kurtosis_dict.values()
+
+        return skew(kurtosisses, bias = False)
+
+
+
+
+
 

--- a/metafeatures/get_metafeatures.py
+++ b/metafeatures/get_metafeatures.py
@@ -1,0 +1,40 @@
+"""
+Script to get metafeatures for all datasets stored in the ../data folder.
+Dumps all the results in a csv called data_metafeatures.csv
+"""
+
+from glob import glob
+import pandas as pd
+
+from dataset_describe import Dataset
+from collections import OrderedDict
+
+
+def get_metafeatures(df):
+    dataset = Dataset(df, dependent_col = 'class', prediction_type='classification')
+   
+    meta_features = OrderedDict()
+    for i in dir(dataset):
+        result = getattr(dataset, i)
+        # print i
+        if not i.startswith('__') and not i.startswith('_') and hasattr(result, '__call__'):
+            meta_features[i] = result()
+
+    return meta_features
+
+
+def main():
+    meta_features = []
+    for i,dataset in enumerate(glob('../data/*')):
+        # Read the data set into memory
+        print 'Processing {0}'.format(dataset)
+        input_data = pd.read_csv(dataset, compression='gzip', sep='\t')
+        meta_features.append(get_metafeatures(input_data))
+        
+        # For testing purposes.
+        # if i == 5:
+        #     pd.DataFrame(meta_features).to_csv('data_metafeatures.csv')
+        #     break
+
+if __name__ == '__main__':
+    main()

--- a/metafeatures/get_metafeatures.py
+++ b/metafeatures/get_metafeatures.py
@@ -19,22 +19,24 @@ def get_metafeatures(df):
         # print i
         if not i.startswith('__') and not i.startswith('_') and hasattr(result, '__call__'):
             meta_features[i] = result()
-
     return meta_features
 
 
 def main():
-    meta_features = []
+    meta_features_all = []
+    print '!'
     for i,dataset in enumerate(glob('../data/*')):
         # Read the data set into memory
         print 'Processing {0}'.format(dataset)
         input_data = pd.read_csv(dataset, compression='gzip', sep='\t')
-        meta_features.append(get_metafeatures(input_data))
+        meta_features = get_metafeatures(input_data)
+        meta_features['dataset'] = dataset
+        meta_features_all.append(meta_features)
         
         # For testing purposes.
-        # if i == 5:
-        #     pd.DataFrame(meta_features).to_csv('data_metafeatures.csv')
-        #     break
+        if i == 15:
+            pd.DataFrame(meta_features_all).to_csv('data_metafeatures.csv')
+            break
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Tried:
 - Benfords Law
 - Threshold based unique values.

Both had a lot of false positives. 
I've discarded Benford as a metric and reduced the maximum number of unique values to 0.001 times the rows in the dataset.

Ultimately used something really hacky. 
Given you've used sklearn's Label Encoder for all your encoding, I can assume encodings start with zero and end with `N - 1` where `N` is the total unique values in the column. So I simply check if the unique of the column is a complete list of natural numbers. :P

There are still some false positives like age, but that's fine for now I guess.

In the next two PRs (over this weekend) I am going to complete covering all metafeatures commonly found else where. No point waiting for an api. Also (given meta-features help), whenever TPOT will face a new dataset, it would need to finds its metafeatures first to recommend the starting population and hence it better be an offering packed with TPOT.  I might be wrong about this.

You can delete #25 as this PR has the monkey_runner script too.

Number of categorical columns for the first few datasets.

![image](https://cloud.githubusercontent.com/assets/6428892/14260476/4e15c490-fac9-11e5-9a53-a8ffa407a40a.png)

